### PR TITLE
Crea clase Linea, LineaCMasMas y refactorea CP DelimitadorDeBloques

### DIFF
--- a/src/cp/ComponenteDeProcesamiento.java
+++ b/src/cp/ComponenteDeProcesamiento.java
@@ -8,6 +8,6 @@ public abstract class ComponenteDeProcesamiento {
 		super();
 	}
 
-	public abstract List<String> ejecutar(List<String> archivo);
+	public abstract List<Linea> ejecutar(List<Linea> archivo);
 
 }

--- a/src/cp/Lenguaje.java
+++ b/src/cp/Lenguaje.java
@@ -20,6 +20,10 @@ public abstract class Lenguaje {
 	public ArrayList<String> getTiposFiltro() {
 		return new ArrayList<>();
 	}
+	
+	public Linea createLinea() {
+		return null;
+	}
 
 	@Override
 	public abstract String toString();

--- a/src/cp/Linea.java
+++ b/src/cp/Linea.java
@@ -1,34 +1,26 @@
 package cp;
 
-public class Linea {
+public abstract class Linea {
 
-	  private int numLinea;
-	  private String codLinea;
-	  private boolean numLineaYaMostrado; //Si es una linea con Marcas sobre bloques else o switch, el toString no agrega numLinea al final
+	  private int numeroLinea;
+	  private String codigoLinea;
+	  private String marca;
 
-	  public Linea(int numLinea, String codLinea) {
-	    this.numLinea = numLinea;
-	    this.codLinea = codLinea;
-	    this.numLineaYaMostrado = false;
-	  }
-
-	  public int getNumLinea() { return numLinea; }
-	  public String getCodLinea() { return codLinea; }
-	  public String toString() {
-		  return numLineaYaMostrado ? codLinea : codLinea + " EN LINEA " + numLinea;
+	  public int getNumeroLinea() { return numeroLinea; }
+	  public String getCodigoLinea() { return codigoLinea; }
+	  public String getMarca() { return marca; }
+	  
+	  public void setCodigoLinea(String codigoLinea) {
+		  this.codigoLinea = codigoLinea;
 	  }
 	  
-	  public Linea setCodLinea(String codLinea) {
-		  this.codLinea = codLinea;
-		  return this;
+	  public void setNumeroLinea(int numeroLinea) {
+		  this.numeroLinea = numeroLinea;
 	  }
 	  
-	  public Linea setNumLinea(int numLinea) {
-		  this.numLinea = numLinea;
-		  return this;
+	  public void setMarca(String marca) {
+		  this.marca = marca;
 	  }
 	  
-	  public void setNumLineaYaMostrado(boolean f) {
-		  this.numLineaYaMostrado = f;
-	  }
+	  public abstract String getLineaConMarca();
 }

--- a/src/cp/Procesamiento.java
+++ b/src/cp/Procesamiento.java
@@ -12,10 +12,12 @@ import cp.exception.UnsupportedLanguageException;
 
 public class Procesamiento {
 
-	private List<String> archivo = new LinkedList<>();
+	private List<Linea> archivo = new LinkedList<>();
 	private List<ComponenteDeProcesamiento> proceso;
-
+	private Lenguaje lenguaje;
+	
 	public Procesamiento(Lenguaje lenguaje) throws UnsupportedLanguageException {
+		this.lenguaje = lenguaje;
 		generarConfiguracion(lenguaje);
 	}
 
@@ -35,10 +37,16 @@ public class Procesamiento {
 	private void leerArchivo(File file) {
 		try(FileReader fr = new FileReader(file);
 				BufferedReader br = new BufferedReader(fr);){
-			String linea;
+			String lineaString;
+			int i = 1;
 			archivo.clear();
-			while((linea = br.readLine()) != null){
+			while((lineaString = br.readLine()) != null){
+				Linea linea = lenguaje.createLinea();
+				linea.setCodigoLinea(lineaString);
+				linea.setMarca("");
+				linea.setNumeroLinea(i);
 				archivo.add(linea);
+				
 			}
 		} catch(Exception e){
 			e.printStackTrace();
@@ -52,7 +60,7 @@ public class Procesamiento {
 	private void escribirArchivo(File file) {
 		try(FileWriter fichero = new FileWriter(file);
 				PrintWriter pw = new PrintWriter(fichero);){
-			archivo.forEach(linea -> pw.println(linea));
+			archivo.forEach(linea -> pw.println(linea.getLineaConMarca()));
 		} catch(Exception e){
 			e.printStackTrace();
 		}

--- a/src/cp/aedd/CMasMasProcedural.java
+++ b/src/cp/aedd/CMasMasProcedural.java
@@ -14,7 +14,7 @@ public class CMasMasProcedural extends Lenguaje {
 		List<ComponenteDeProcesamiento> proceso = new LinkedList<>();
 		proceso.add(new FormatoEstandar());
 		proceso.add(new DelimitadorDeBloques());
-		proceso.add(new DelimitadorDeFunciones());
+		//proceso.add(new DelimitadorDeFunciones());
 		return proceso;
 	}
 	
@@ -31,6 +31,11 @@ public class CMasMasProcedural extends Lenguaje {
 		return tiposFiltro;
 	}
 
+	@Override
+	public LineaCMasMas createLinea() {
+		return new LineaCMasMas();
+	}
+	
 	@Override
 	public String toString() {
 		return "C++ Procedural";

--- a/src/cp/aedd/DelimitadorDeBloques.java
+++ b/src/cp/aedd/DelimitadorDeBloques.java
@@ -10,71 +10,58 @@ import cp.Linea;
 public class DelimitadorDeBloques extends ComponenteDeProcesamiento {
 
 	@Override
-	public List<String> ejecutar(List<String> archivo) {
-		List<String> archivoTransformado = new LinkedList<>();
+	public List<Linea> ejecutar(List<Linea> archivo) {
+		List<Linea> archivoTransformado = new LinkedList<>();
 		//ArrayList es más eficiente para quitar al final, es decir, como pila
-		List<Linea> pilaDeBloquesAbiertos = new ArrayList<>();
-		List<Linea> pilaDeIf = new ArrayList<>();
-		List<Linea> pilaDeSwitch = new ArrayList<>();
-		int numLinea = 1;
-		for(String lineaOriginal: archivo) {
-			String lineaConMarca = "";
-			if(abreBloque(lineaOriginal.charAt(lineaOriginal.length() - 1))){
-				Linea lineaEnPila = new Linea(numLinea,"");
-				String aux = lineaOriginal.substring(0, lineaOriginal.length() - 2);
-				if(aux.endsWith(":")){
-					aux = aux.substring(0, aux.length() - 1);
+		List<LineaCMasMas> pilaDeBloquesAbiertos = new ArrayList<>();
+		List<LineaCMasMas> pilaDeIf = new ArrayList<>();
+		List<LineaCMasMas> pilaDeSwitch = new ArrayList<>();
+		for(int numLinea=1; numLinea <= archivo.size(); numLinea++){
+			LineaCMasMas lineaOriginalCMasMas = (LineaCMasMas)archivo.get(numLinea-1);
+			if(lineaOriginalCMasMas.abreBloque()) {
+				LineaCMasMas lineaEnPila = new LineaCMasMas();
+				lineaEnPila.setNumeroLinea(numLinea);
+				lineaEnPila.setCodigoLinea("");
+				lineaEnPila.setMarca(lineaOriginalCMasMas.getCodigoLineaSinFinal());
+				if(lineaOriginalCMasMas.esIf()) {
+					pilaDeIf.add(lineaEnPila);
 				}
-				if(lineaOriginal.startsWith("if")){
-					pilaDeIf.add(lineaEnPila.setCodLinea(aux));
+				else if(lineaOriginalCMasMas.esSwitch()) {
+					pilaDeSwitch.add(lineaEnPila);
 				}
-				else if(lineaOriginal.startsWith("switch")){
-					pilaDeSwitch.add(lineaEnPila.setCodLinea(aux));
+				if(lineaOriginalCMasMas.tieneElse()) {
+					String aux = "EN LINEA " + numLinea + " DE " + pilaDeIf.remove(pilaDeIf.size() - 1).getMarcaConNumero();
+					lineaEnPila.addMarca(aux) ;
+					lineaEnPila.setNumeroLineaYaMostrado(true);
 				}
-				if(lineaOriginal.contains("else")){
-					aux = aux + " EN LINEA " + numLinea + " DE " + pilaDeIf.remove(pilaDeIf.size() - 1).toString() ;
-					lineaEnPila.setNumLineaYaMostrado(true);
-				}
-				else{
-					if(lineaOriginal.startsWith("case") || lineaOriginal.startsWith("default")){
-						aux = aux + " EN LINEA " + numLinea + " DE " + pilaDeSwitch.get(pilaDeSwitch.size() - 1).toString();
-						lineaEnPila.setNumLineaYaMostrado(true);
+				else {
+					if(lineaOriginalCMasMas.esCase() || lineaOriginalCMasMas.esDefault()) {
+						String aux = "EN LINEA " + numLinea + " DE " + pilaDeSwitch.get(pilaDeSwitch.size() - 1).getMarcaConNumero();
+						lineaEnPila.addMarca(aux) ;
+						lineaEnPila.setNumeroLineaYaMostrado(true);
 					}
 				}
-				if(!lineaOriginal.startsWith("do")) {
-					pilaDeBloquesAbiertos.add(lineaEnPila.setCodLinea(aux));
+				if(!lineaOriginalCMasMas.esDo()) {
+					pilaDeBloquesAbiertos.add(lineaEnPila);
 				}
-				lineaConMarca = lineaOriginal;
 			}
 			else{
-				if(cierraBloque(lineaOriginal.charAt(lineaOriginal.length() - 1))){
-					String marca = "//CIERRA EL BLOQUE DE " + pilaDeBloquesAbiertos.remove(pilaDeBloquesAbiertos.size() - 1).toString();
-					lineaConMarca = lineaOriginal + marca;
-					if(marca.startsWith("//CIERRA EL BLOQUE DE switch")){
+				if(lineaOriginalCMasMas.cierraBloque()){
+					LineaCMasMas lineaTopePila = pilaDeBloquesAbiertos.remove(pilaDeBloquesAbiertos.size() - 1);
+					lineaOriginalCMasMas.setMarca("CIERRA EL BLOQUE DE " + lineaTopePila.getMarcaConNumero());
+					if(lineaTopePila.getMarca().startsWith("switch")){
 						pilaDeSwitch.remove(pilaDeSwitch.size() - 1);
 					}
 				}
 				else{
-					if(lineaOriginal.equals("};")){
-						String marca = "//CIERRA LA DEFINICION DE " + pilaDeBloquesAbiertos.remove(pilaDeBloquesAbiertos.size() - 1).toString();
-						lineaConMarca = lineaOriginal + marca;
-					}
-					else{
-						lineaConMarca = lineaOriginal;
+					if(lineaOriginalCMasMas.cierraStruct()){
+						LineaCMasMas lineaTopePila = pilaDeBloquesAbiertos.remove(pilaDeBloquesAbiertos.size() - 1);
+						lineaOriginalCMasMas.setMarca("CIERRA LA DEFINICION DE " + lineaTopePila.getMarcaConNumero());
 					}
 				}
 			}
-			archivoTransformado.add(lineaConMarca);
-			numLinea++;
+			archivoTransformado.add(lineaOriginalCMasMas);
 		}
 		return archivoTransformado;
-	}
-
-	private boolean abreBloque(char c) {
-		return (c == '{');
-	}
-
-	private boolean cierraBloque(char c) {
-		return (c == '}');
 	}
 }

--- a/src/cp/aedd/DelimitadorDeFunciones.java
+++ b/src/cp/aedd/DelimitadorDeFunciones.java
@@ -11,9 +11,9 @@ public class DelimitadorDeFunciones extends ComponenteDeProcesamiento {
 	//TODO Hacer que la Clase Linea tenga atributo marca, atributo linea original y metodos utiles comunes a todos los cp
 	
 	@Override
-	public List<String> ejecutar(List<String> archivo) {
+	public List<Linea> ejecutar(List<Linea> archivo) {
 		// Uso Array List porque es mas eficiente la operacion get(i) y no necesito hacer add()
-		List<String> archivoTransformado = new ArrayList<>(archivo);
+		List<Linea> archivoTransformado = new ArrayList<>(archivo);
 		List<Linea> pilaDeBloquesAbiertos = new ArrayList<>();
 		boolean apilar = false;
 		int numLinea = 1;

--- a/src/cp/aedd/FormatoEstandar.java
+++ b/src/cp/aedd/FormatoEstandar.java
@@ -3,11 +3,12 @@ package cp.aedd;
 import java.util.List;
 
 import cp.ComponenteDeProcesamiento;
+import cp.Linea;
 
 public class FormatoEstandar extends ComponenteDeProcesamiento {
 
 	@Override
-	public List<String> ejecutar(List<String> archivo) {
+	public List<Linea> ejecutar(List<Linea> archivo) {
 		//TODO Hacer.
 		return archivo;
 	}

--- a/src/cp/aedd/LineaCMasMas.java
+++ b/src/cp/aedd/LineaCMasMas.java
@@ -1,0 +1,75 @@
+package cp.aedd;
+
+import cp.Linea;
+
+public class LineaCMasMas extends Linea {
+	
+	private boolean numeroLineaYaMostrado;
+
+	@Override
+	public String getLineaConMarca() {
+		return (!this.getMarca().isEmpty()) ? this.getCodigoLinea() + "// " + this.getMarca() : this.getCodigoLinea();
+	}
+	
+	public boolean abreBloque() {
+		return this.getCodigoLinea().charAt(getCodigoLinea().length() - 1) == '{';
+	}
+	
+	public boolean cierraBloque() {
+		return this.getCodigoLinea().charAt(getCodigoLinea().length() - 1) == '}';
+	}
+	
+	public String getCodigoLineaSinFinal() {
+		String aux = this.getCodigoLinea().substring(0, this.getCodigoLinea().length() - 2);
+		if(aux.endsWith(":")){
+			aux = aux.substring(0, aux.length() - 1);
+		}
+		return aux;
+	}
+
+	
+	public boolean esIf() {
+		return this.getCodigoLinea().startsWith("if");
+	}
+	
+	public boolean esSwitch() {
+		return this.getCodigoLinea().startsWith("switch");
+	}
+	
+	public boolean esDo() {
+		return this.getCodigoLinea().startsWith("do");
+	}
+	
+	public boolean tieneElse() {
+		return this.getCodigoLinea().contains("else");
+	}
+	
+	public void setNumeroLineaYaMostrado(boolean flag) {
+		this.numeroLineaYaMostrado = flag;
+	}
+	
+	public boolean getNumeroLineaYaMostrado() {
+		return this.numeroLineaYaMostrado;
+	}
+	
+	public boolean esCase() {
+		return this.getCodigoLinea().startsWith("case");
+	}
+	
+	public boolean esDefault() {
+		return this.getCodigoLinea().startsWith("default");
+	}
+	
+	public boolean cierraStruct() {
+		return this.getCodigoLinea().equals("};");
+	}
+	
+	public void addMarca(String nuevaMarca) {
+		String viejaMarca = this.getMarca();
+		this.setMarca(viejaMarca + " " + nuevaMarca);
+	}
+	
+	public String getMarcaConNumero() {
+		return numeroLineaYaMostrado ? this.getMarca() : this.getMarca() + " EN LINEA " + this.getNumeroLinea();
+	}
+}

--- a/src/ui/Main.java
+++ b/src/ui/Main.java
@@ -152,8 +152,8 @@ public class Main extends Application {
 	public List<Lenguaje> lenguajesSoportados() {
 		List<Lenguaje> lenguajesSoportados = new ArrayList<>();
 		lenguajesSoportados.add(new CMasMasProcedural());
-		lenguajesSoportados.add(new GNUSmalltalk());
-		lenguajesSoportados.add(new PharoToGNUSmalltalk());
+		//lenguajesSoportados.add(new GNUSmalltalk());
+		//lenguajesSoportados.add(new PharoToGNUSmalltalk());
 		return lenguajesSoportados;
 	}
 }


### PR DESCRIPTION
Linea pasa a ser clase abstracta y cada lenguaje implementa su propia
clase linea. Tambien crea la implementacion de Linea para el lenguaje
C++: LineaCMasMas.

No me gusta el downcasting que se hace de la lista. A futuro puede traer
complaciones me parece. Ver si se puede modificar el disenio de las clases
para solucionar este problema.

Falta:
 - Implementar este cambio en todos los CP de Smalltalk
 - Implementar este cambio en CP DelimitadorDeFunciones

**NO MERGEAR TODAVIA**